### PR TITLE
refactor: remove redundant patient routing segment

### DIFF
--- a/frontend/soc/src/App.jsx
+++ b/frontend/soc/src/App.jsx
@@ -21,12 +21,12 @@ import './styles/global.css';
 
 const { Content } = Layout;
 
-// Component to redirect authenticated users to their patient home
+// Component to redirect authenticated users to their home
 const HomeRedirect = () => {
   const { user } = useAuthStore();
 
   if (user?.uid) {
-    return <Navigate to={`/patient/${user.uid}`} replace />;
+    return <Navigate to="/home" replace />;
   }
 
   return <Navigate to="/login" replace />;
@@ -79,18 +79,48 @@ const App = () => {
         {/* Redirect legacy routes */}
         <Route path="/patients" element={<Navigate to="/" replace />} />
 
-        {/* Patient routes with patient sidebar */}
-        <Route path="/patient/:patientId" element={
+        {/* Main application routes with sidebar */}
+        <Route path="/home" element={
           <ProtectedRoute>
             <PatientLayout />
           </ProtectedRoute>
         }>
           <Route index element={<PatientHome />} />
-          <Route path="calendar" element={<PatientCalendar />} />
-          <Route path="list" element={<CareItemsListPage />} />
-          <Route path="budget" element={<Budget />} />
-          <Route path="info" element={<ClientProfile />} />
-          <Route path="settings" element={<PatientSettings />} />
+        </Route>
+        <Route path="/calendar" element={
+          <ProtectedRoute>
+            <PatientLayout />
+          </ProtectedRoute>
+        }>
+          <Route index element={<PatientCalendar />} />
+        </Route>
+        <Route path="/list" element={
+          <ProtectedRoute>
+            <PatientLayout />
+          </ProtectedRoute>
+        }>
+          <Route index element={<CareItemsListPage />} />
+        </Route>
+        <Route path="/budget" element={
+          <ProtectedRoute>
+            <PatientLayout />
+          </ProtectedRoute>
+        }>
+          <Route index element={<Budget />} />
+        </Route>
+        <Route path="/profile" element={
+          <ProtectedRoute>
+            <PatientLayout />
+          </ProtectedRoute>
+        }>
+          <Route index element={<ClientProfile />} />
+        </Route>
+        <Route path="/settings" element={
+          <ProtectedRoute>
+            <PatientLayout />
+          </ProtectedRoute>
+        }>
+          <Route index element={<PatientSettings />} />
         </Route>
       </Routes>
     </Router>

--- a/frontend/soc/src/components/Layout/PatientLayout.jsx
+++ b/frontend/soc/src/components/Layout/PatientLayout.jsx
@@ -1,26 +1,20 @@
 import React from 'react';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { Layout } from 'antd';
 import PatientSidebar from './PatientSidebar';
-import { patientsData } from '../../data/mockData';
 
 const { Content } = Layout;
 
 /**
- * Layout wrapper for patient pages
+ * Layout wrapper for main application pages
  * **/
 const PatientLayout = () => {
-  const { patientId } = useParams();
-
-  // Get patient data (in real app, this would be an API call)
-  const patient = patientsData.find(p => p.id === patientId) || patientsData[0];
-
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <PatientSidebar />
       <Layout style={{ marginLeft: 240, background: '#ffffff' }}>
         <Content style={{ background: '#ffffff' }}>
-          <Outlet context={{ patient }} />
+          <Outlet />
         </Content>
       </Layout>
     </Layout>

--- a/frontend/soc/src/components/Layout/PatientSidebar.jsx
+++ b/frontend/soc/src/components/Layout/PatientSidebar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { Layout, Button, Typography, Avatar, Space, message } from 'antd';
 import useAuthStore from '../../store/authStore';
 import {
@@ -18,12 +18,11 @@ const { Sider } = Layout;
 const { Text } = Typography;
 
 /**
- * Patient-specific navigation sidebar
+ * Main application navigation sidebar
  * **/
 const PatientSidebar = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { patientId } = useParams();
   const { logout, user } = useAuthStore();
 
   // Get user display information
@@ -50,37 +49,37 @@ const PatientSidebar = () => {
   const menuItems = [
     {
       key: 'home',
-      path: `/patient/${patientId}`,
+      path: '/home',
       icon: <HomeOutlined />,
       label: 'Home'
     },
     {
       key: 'calendar',
-      path: `/patient/${patientId}/calendar`,
+      path: '/calendar',
       icon: <CalendarOutlined />,
       label: 'Calendar'
     },
     {
       key: 'list',
-      path: `/patient/${patientId}/list`,
+      path: '/list',
       icon: <UnorderedListOutlined />,
       label: 'List'
     },
     {
       key: 'budget',
-      path: `/patient/${patientId}/budget`,
+      path: '/budget',
       icon: <DollarOutlined />,
       label: 'Budget'
     },
     {
-      key: 'info',
-      path: `/patient/${patientId}/info`,
+      key: 'profile',
+      path: '/profile',
       icon: <UserOutlined />,
       label: 'Client Profile'
     },
     {
       key: 'settings',
-      path: `/patient/${patientId}/settings`,
+      path: '/settings',
       icon: <SettingFilled />,
       label: 'Settings'
     }

--- a/frontend/soc/src/pages/Budget.jsx
+++ b/frontend/soc/src/pages/Budget.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Typography, Card, Button, Space, App, Modal, message } from 'antd';
 import { PlusOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
-import { useParams } from 'react-router-dom';
 import { useBudgetAnalytics, useCategories, useDeleteCategory, useDeleteSubcategory } from '../hooks/useBudgetQuery';
+import useAuthStore from '../store/authStore';
 import BudgetSummaryCard from '../components/Budget/BudgetSummaryCard';
 import CategoryBudgetCard from '../components/Budget/CategoryBudgetCard';
 import BudgetAnalytics from '../components/Budget/BudgetAnalytics';
@@ -12,7 +12,8 @@ import SubcategoryModal from '../components/Budget/SubcategoryModal';
 const { Title, Text } = Typography;
 
 const BudgetContent = () => {
-  const { patientId } = useParams();
+  const { user } = useAuthStore();
+  const userId = user?.uid;
 
   // Modal state
   const [categoryModalOpen, setCategoryModalOpen] = useState(false);
@@ -25,11 +26,11 @@ const BudgetContent = () => {
   const { modal } = App.useApp();
 
   // TanStack Query hooks
-  const { data: budgetAnalytics, isLoading: analyticsLoading, error: analyticsError } = useBudgetAnalytics(patientId);
+  const { data: budgetAnalytics, isLoading: analyticsLoading, error: analyticsError } = useBudgetAnalytics(userId);
   // eslint-disable-next-line no-unused-vars
-  const { data: categories = [], isLoading: categoriesLoading } = useCategories(patientId);
-  const deleteCategoryMutation = useDeleteCategory(patientId);
-  const deleteSubcategoryMutation = useDeleteSubcategory(patientId);
+  const { data: categories = [], isLoading: categoriesLoading } = useCategories(userId);
+  const deleteCategoryMutation = useDeleteCategory(userId);
+  const deleteSubcategoryMutation = useDeleteSubcategory(userId);
 
   const isLoading = analyticsLoading || categoriesLoading;
 
@@ -228,7 +229,7 @@ const BudgetContent = () => {
         onCancel={closeCategoryModal}
         mode={modalMode}
         category={selectedCategory}
-        patientId={patientId}
+        patientId={userId}
       />
 
       {/* Subcategory Modal */}
@@ -238,7 +239,7 @@ const BudgetContent = () => {
         mode={modalMode}
         category={selectedCategory}
         subcategory={selectedSubcategory}
-        patientId={patientId}
+        patientId={userId}
       />
     </div>
   );


### PR DESCRIPTION
- Update routing structure to remove /patient/:patientId segments
- Change routes to clean paths: /home, /calendar, /list, /budget, /profile, /settings
- Update navigation links to use new direct routes
- Modify Budget component to use user ID from auth store instead of URL params
- Simplify PatientLayout by removing patient data dependencies
- Update HomeRedirect to point to /home instead of /patient/:userId
- Rename client profile route from /info to /profile for clarity
- Remove unused useParams import from PatientSidebar

This better reflects the app's purpose: caregivers managing care for persons with special needs