### PR TITLE
feat: auto-create client profile on GET with empty values

### DIFF
--- a/backend/tests/routes/users.test.js
+++ b/backend/tests/routes/users.test.js
@@ -456,7 +456,7 @@ describe('Users API - Client Profile Endpoints', () => {
       expect(response.body.client_profile.is_active).toBe(true);
     });
 
-    it('should return 404 when user has no client profile (not yet created)', async () => {
+    it('should auto-create client profile when user has no client profile', async () => {
       const mockUserDoc = {
         exists: true,
         data: () => ({
@@ -467,27 +467,36 @@ describe('Users API - Client Profile Endpoints', () => {
       };
 
       mockDoc.get.mockResolvedValue(mockUserDoc);
+      mockDoc.update.mockResolvedValue();
 
       const response = await request(app)
         .get('/api/users/client-profile')
-        .expect(404);
+        .expect(200);
 
-      expect(response.body.error).toBe('Client profile not found');
-      expect(response.body.message).toBe('No client profile has been set up for this user');
+      expect(response.body.user_id).toBe('test-uid');
+      expect(response.body.client_profile).toBeDefined();
+      expect(response.body.client_profile.full_name).toBeNull();
+      expect(response.body.client_profile.is_active).toBe(true);
+      expect(mockDoc.update).toHaveBeenCalled();
     });
 
-    it('should return 404 when user document does not exist (not yet created)', async () => {
+    it('should auto-create user document and client profile when user document does not exist', async () => {
       const mockUserDoc = {
         exists: false
       };
 
       mockDoc.get.mockResolvedValue(mockUserDoc);
+      mockDoc.set.mockResolvedValue();
 
       const response = await request(app)
         .get('/api/users/client-profile')
-        .expect(404);
+        .expect(200);
 
-      expect(response.body.error).toBe('Client profile not found');
+      expect(response.body.user_id).toBe('test-uid');
+      expect(response.body.client_profile).toBeDefined();
+      expect(response.body.client_profile.full_name).toBeNull();
+      expect(response.body.client_profile.is_active).toBe(true);
+      expect(mockDoc.set).toHaveBeenCalled();
     });
 
     it('should handle database errors', async () => {

--- a/backend/utils/clientProfile.js
+++ b/backend/utils/clientProfile.js
@@ -157,6 +157,32 @@ function updateClientProfileData(existingProfile, updateData) {
 }
 
 /**
+ * Initialize empty client profile with default values
+ * @returns {Object} Initial client profile data
+ */
+function initializeClientProfile() {
+  return {
+    full_name: null,
+    date_of_birth: null,
+    sex: null,
+    age: null,
+    mobile_number: null,
+    email_address: null,
+    postal_address: null,
+    emergency_contacts: null,
+    notes: null,
+    medical_conditions: null,
+    allergies: null,
+    medications: null,
+    accessibility_needs: null,
+    latest_vitals: null,
+    is_active: true,
+    created_at: new Date(),
+    updated_at: new Date()
+  };
+}
+
+/**
  * Filter users by search criteria
  * @param {Array} users - Array of users with client profiles
  * @param {string} searchTerm - Search term to filter by
@@ -183,5 +209,6 @@ module.exports = {
   formatClientProfileResponse,
   prepareClientProfileData,
   updateClientProfileData,
+  initializeClientProfile,
   filterUsersBySearch
 };


### PR DESCRIPTION
- Add initializeClientProfile function to create empty client profile with default values
- Update GET /client-profile to auto-create user document and client profile if missing
- Update tests to reflect new auto-create behavior
- Ensures consistent behavior between user profile and client profile endpoints